### PR TITLE
feat: (#10) 메인 페이지 상수/타입/훅 분리와 리팩터링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@modern-kit/utils": "^2.5.0",
         "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1246,6 +1247,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modern-kit/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@modern-kit/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-uLkRvXuCjRGf/mcJs/gaPBvXuyBxfAmXeFFvy3/pWKgqLtL8nqII9+tojydocll5ioFlwct9jccMlgRDEeFjgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@mswjs/interceptors": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@modern-kit/utils": "^2.5.0",
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,28 +1,40 @@
 import axios from "axios";
 import type { LoginRequest, LoginResponse, SignupRequest, SignupResponse, LogoutResponse, RefreshTokenResponse } from "../types/auth";
 
-function requestLogin(loginData: LoginRequest): Promise<LoginResponse> {
-  return axios.post<LoginResponse>(`${import.meta.env.VITE_API_BASE_URL}/api/auth/login`, loginData, {
-    withCredentials: true,
-  }).then(res => res.data);
+async function requestLogin(loginData: LoginRequest): Promise<LoginResponse> {
+  const res = await axios.post<LoginResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/api/auth/login`,
+    loginData,
+    { withCredentials: true }
+  );
+  return res.data;
 }
 
-function requestSignup(signupData: SignupRequest): Promise<SignupResponse> {
-  return axios.post<SignupResponse>(`${import.meta.env.VITE_API_BASE_URL}/api/auth/signup`, signupData, {
-    withCredentials: true,
-  }).then(res => res.data);
+async function requestSignup(signupData: SignupRequest): Promise<SignupResponse> {
+  const res = await axios.post<SignupResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/api/auth/signup`,
+    signupData,
+    { withCredentials: true }
+  );
+  return res.data;
 }
 
-function requestLogout(): Promise<LogoutResponse> {
-  return axios.post<LogoutResponse>(`${import.meta.env.VITE_API_BASE_URL}/api/auth/logout`, {}, {
-    withCredentials: true,
-  }).then(res => res.data);
+async function requestLogout(): Promise<LogoutResponse> {
+  const res = await axios.post<LogoutResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/api/auth/logout`,
+    {},
+    { withCredentials: true }
+  );
+  return res.data;
 }
 
-function requestRefreshToken(): Promise<RefreshTokenResponse> {
-  return axios.post<RefreshTokenResponse>(`${import.meta.env.VITE_API_BASE_URL}/api/auth/token`, {}, {
-    withCredentials: true,
-  }).then(res => res.data);
+async function requestRefreshToken(): Promise<RefreshTokenResponse> {
+  const res = await axios.post<RefreshTokenResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/api/auth/token`,
+    {},
+    { withCredentials: true }
+  );
+  return res.data;
 }
 
 export { requestLogin, requestSignup, requestLogout, requestRefreshToken };

--- a/src/apis/webtoons.ts
+++ b/src/apis/webtoons.ts
@@ -1,0 +1,7 @@
+import type { Webtoon } from "../types/webtoon";
+import axios from "axios";
+
+export const requestAllWebtoons = async (sort: string): Promise<Webtoon[]> => {
+  const res = await axios.get(`${import.meta.env.VITE_API_BASE_URL}/api/webtoons?sort=${sort}`);
+  return res.data.data.webtoons;
+};

--- a/src/constants/date.constants.ts
+++ b/src/constants/date.constants.ts
@@ -1,0 +1,9 @@
+export const DAY_MAPPING = {
+  mon: "월요웹툰",
+  tue: "화요웹툰",
+  wed: "수요웹툰",
+  thu: "목요웹툰",
+  fri: "금요웹툰",
+  sat: "토요웹툰",
+  sun: "일요웹툰",
+} as const;

--- a/src/constants/webtoon.constants.ts
+++ b/src/constants/webtoon.constants.ts
@@ -1,1 +1,13 @@
 export const WEBTOON_SORT_OPTIONS = ["favorite", "updated", "view", "rate"] as const;
+
+export type WebtoonSortOption = typeof WEBTOON_SORT_OPTIONS[number];
+
+export const BUTTON_INFOS: {
+  type: WebtoonSortOption;
+  content: string;
+}[] = [
+  { type: "favorite", content: "인기순" },
+  { type: "updated", content: "· 업데이트순" },
+  { type: "view", content: "· 조회순" },
+  { type: "rate", content: "· 별점순" },
+];

--- a/src/constants/webtoon.constants.ts
+++ b/src/constants/webtoon.constants.ts
@@ -1,0 +1,1 @@
+export const WEBTOON_SORT_OPTIONS = ["favorite", "updated", "view", "rate"] as const;

--- a/src/hooks/useSortQuery.ts
+++ b/src/hooks/useSortQuery.ts
@@ -7,23 +7,22 @@ import { contains } from "@modern-kit/utils";
 export const useSortQuery = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   
-  const rawSort = searchParams.get("sort");
+  const rawSortParam = searchParams.get("sort");
   
-  const sort: WebtoonSortOption = contains(WEBTOON_SORT_OPTIONS, rawSort)
-  ? rawSort
+  const sortParam: WebtoonSortOption = contains(WEBTOON_SORT_OPTIONS, rawSortParam)
+  ? rawSortParam
   : "favorite";
 
   useEffect(() => {
-    if (!rawSort) {
-      searchParams.set("sort", "favorite");
-      setSearchParams(searchParams);
+    if (!rawSortParam) {
+      setSortParam("favorite");
     }
-  }, [rawSort]);
+  }, [rawSortParam]);
 
-  const setSort = (value: WebtoonSortOption) => {
-    searchParams.set("sort", value);
+  const setSortParam = (sortOption: WebtoonSortOption) => {
+    searchParams.set("sort", sortOption);
     setSearchParams(searchParams);
   };
 
-  return { sort, setSort };
+  return { sortParam, setSortParam };
 };

--- a/src/hooks/useSortQuery.ts
+++ b/src/hooks/useSortQuery.ts
@@ -1,0 +1,30 @@
+import { WEBTOON_SORT_OPTIONS } from "../constants/webtoon.constants";
+import type { WebtoonSortOption } from "../types/webtoon";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router";
+
+export const useSortQuery = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  
+  const rawSort = searchParams.get("sort");
+  
+  const sort: WebtoonSortOption = WEBTOON_SORT_OPTIONS.includes(
+    rawSort as WebtoonSortOption
+  )
+  ? (rawSort as WebtoonSortOption)
+  : "favorite";
+
+  useEffect(() => {
+    if (!rawSort) {
+      searchParams.set("sort", "favorite");
+      setSearchParams(searchParams);
+    }
+  }, [rawSort]);
+
+  const setSort = (value: WebtoonSortOption) => {
+    searchParams.set("sort", value);
+    setSearchParams(searchParams);
+  };
+
+  return { sort, setSort };
+};

--- a/src/hooks/useSortQuery.ts
+++ b/src/hooks/useSortQuery.ts
@@ -2,16 +2,15 @@ import { WEBTOON_SORT_OPTIONS } from "../constants/webtoon.constants";
 import type { WebtoonSortOption } from "../types/webtoon";
 import { useEffect } from "react";
 import { useSearchParams } from "react-router";
+import { contains } from "@modern-kit/utils";
 
 export const useSortQuery = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   
   const rawSort = searchParams.get("sort");
   
-  const sort: WebtoonSortOption = WEBTOON_SORT_OPTIONS.includes(
-    rawSort as WebtoonSortOption
-  )
-  ? (rawSort as WebtoonSortOption)
+  const sort: WebtoonSortOption = contains(WEBTOON_SORT_OPTIONS, rawSort)
+  ? rawSort
   : "favorite";
 
   useEffect(() => {

--- a/src/hooks/useWebtoons.ts
+++ b/src/hooks/useWebtoons.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import type { Webtoon, WebtoonSortOption } from "../types/webtoon";
+import { requestAllWebtoons } from "../apis/webtoons";
+
+function useWebtoons(sort: WebtoonSortOption) {
+  const [webtoons, setWebtoons] = useState<Webtoon[]>([]);
+
+  useEffect(() => {
+    const getWebtoons = async () => {
+      try {
+        const data = await requestAllWebtoons(sort);
+        setWebtoons(data);
+      } catch (err: any) {
+        console.error("웹툰 목록 불러오기 실패:", err);
+      }
+    };
+
+    getWebtoons();
+  }, [sort]);
+
+  return webtoons;
+}
+
+export default useWebtoons;

--- a/src/pages/WebtoonMain.tsx
+++ b/src/pages/WebtoonMain.tsx
@@ -1,20 +1,22 @@
 import DaySection from "../components/DaySection";
-import type { DayOfWeek, MainSortOption, Webtoon } from "../types/webtoon";
-import { mockWebtoons } from "../mocks/models/webtoon";
-import { useState } from "react";
-
-const days: DayOfWeek[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+import { DAY_MAPPING } from "../constants/date.constants";
+import type { DayOfWeek, Webtoon } from "../types/webtoon";
+import { useSortQuery } from "../hooks/useSortQuery";
+import useWebtoons from "../hooks/useWebtoons";
 
 function WebtoonMain() {
-  const [sort, setSort] = useState<MainSortOption>("like");
+  const days = Object.keys(DAY_MAPPING) as DayOfWeek[];
+  
+  const { sort, setSort } = useSortQuery();
+  const webtoons = useWebtoons(sort);
 
   return (
     <div className="mt-[25px]">
       <div className="mb-2 text-sm flex items-center">
         <span className="text-xl font-semibold">요일별 전체 웹툰</span>
         <button 
-        onClick={() => setSort("like")} 
-        className={`ml-4 ${sort === "like" ? "text-site-red" : ""}`}
+        onClick={() => setSort("favorite")} 
+        className={`ml-4 ${sort === "favorite" ? "text-site-red" : ""}`}
         >
           인기순
         </button>
@@ -39,7 +41,7 @@ function WebtoonMain() {
       </div>
       <main className="flex mt-[15px]">
         {days.map((day) => {
-          const filtered = mockWebtoons.filter(
+          const filtered = webtoons.filter(
             (webtoon: Webtoon) => webtoon.day_of_week === day
           );
 

--- a/src/pages/WebtoonMain.tsx
+++ b/src/pages/WebtoonMain.tsx
@@ -4,6 +4,7 @@ import type { Webtoon } from "../types/webtoon";
 import { useSortQuery } from "../hooks/useSortQuery";
 import useWebtoons from "../hooks/useWebtoons";
 import { objectKeys } from "@modern-kit/utils";
+import { BUTTON_INFOS } from "../constants/webtoon.constants";
 
 function WebtoonMain() {
   const days = objectKeys(DAY_MAPPING);
@@ -14,31 +15,16 @@ function WebtoonMain() {
   return (
     <div className="mt-[25px]">
       <div className="mb-2 text-sm flex items-center">
-        <span className="text-xl font-semibold">요일별 전체 웹툰</span>
-        <button 
-        onClick={() => setSortParam("favorite")} 
-        className={`ml-4 ${sortParam === "favorite" ? "text-site-red" : ""}`}
-        >
-          인기순
-        </button>
-        <button 
-        onClick={() => setSortParam("updated")} 
-        className={`ml-1 ${sortParam === "updated" ? "text-site-red" : ""}`}
-        >
-          &middot; 업데이트순
-        </button>
-        <button 
-        onClick={() => setSortParam("view")} 
-        className={`ml-1 ${sortParam === "view" ? "text-site-red" : ""}`}
-        >
-          &middot; 조회순
-        </button>
-        <button 
-        onClick={() => setSortParam("rate")} 
-        className={`ml-1 ${sortParam === "rate" ? "text-site-red" : ""}`}
-        >
-          &middot; 별점순
-        </button>
+        <span className="mr-4 text-xl font-semibold">요일별 전체 웹툰</span>
+        {BUTTON_INFOS.map((item) => (
+          <button
+            key={item.type}
+            onClick={() => setSortParam(item.type)}
+            className={`ml-1 ${sortParam === item.type ? "text-site-red" : ""}`}
+          >
+            {item.content}
+          </button>
+        ))}
       </div>
       <main className="flex mt-[15px]">
         {days.map((day) => {

--- a/src/pages/WebtoonMain.tsx
+++ b/src/pages/WebtoonMain.tsx
@@ -1,11 +1,12 @@
 import DaySection from "../components/DaySection";
 import { DAY_MAPPING } from "../constants/date.constants";
-import type { DayOfWeek, Webtoon } from "../types/webtoon";
+import type { Webtoon } from "../types/webtoon";
 import { useSortQuery } from "../hooks/useSortQuery";
 import useWebtoons from "../hooks/useWebtoons";
+import { objectKeys } from "@modern-kit/utils";
 
 function WebtoonMain() {
-  const days = Object.keys(DAY_MAPPING) as DayOfWeek[];
+  const days = objectKeys(DAY_MAPPING);
   
   const { sort, setSort } = useSortQuery();
   const webtoons = useWebtoons(sort);

--- a/src/pages/WebtoonMain.tsx
+++ b/src/pages/WebtoonMain.tsx
@@ -8,34 +8,34 @@ import { objectKeys } from "@modern-kit/utils";
 function WebtoonMain() {
   const days = objectKeys(DAY_MAPPING);
   
-  const { sort, setSort } = useSortQuery();
-  const webtoons = useWebtoons(sort);
+  const { sortParam, setSortParam } = useSortQuery();
+  const webtoons = useWebtoons(sortParam);
 
   return (
     <div className="mt-[25px]">
       <div className="mb-2 text-sm flex items-center">
         <span className="text-xl font-semibold">요일별 전체 웹툰</span>
         <button 
-        onClick={() => setSort("favorite")} 
-        className={`ml-4 ${sort === "favorite" ? "text-site-red" : ""}`}
+        onClick={() => setSortParam("favorite")} 
+        className={`ml-4 ${sortParam === "favorite" ? "text-site-red" : ""}`}
         >
           인기순
         </button>
         <button 
-        onClick={() => setSort("updated")} 
-        className={`ml-1 ${sort === "updated" ? "text-site-red" : ""}`}
+        onClick={() => setSortParam("updated")} 
+        className={`ml-1 ${sortParam === "updated" ? "text-site-red" : ""}`}
         >
           &middot; 업데이트순
         </button>
         <button 
-        onClick={() => setSort("view")} 
-        className={`ml-1 ${sort === "view" ? "text-site-red" : ""}`}
+        onClick={() => setSortParam("view")} 
+        className={`ml-1 ${sortParam === "view" ? "text-site-red" : ""}`}
         >
           &middot; 조회순
         </button>
         <button 
-        onClick={() => setSort("rate")} 
-        className={`ml-1 ${sort === "rate" ? "text-site-red" : ""}`}
+        onClick={() => setSortParam("rate")} 
+        className={`ml-1 ${sortParam === "rate" ? "text-site-red" : ""}`}
         >
           &middot; 별점순
         </button>

--- a/src/types/webtoon.ts
+++ b/src/types/webtoon.ts
@@ -1,8 +1,6 @@
 import { DAY_MAPPING } from "../constants/date.constants";
-import { WEBTOON_SORT_OPTIONS } from "../constants/webtoon.constants";
 
 type DayOfWeek = keyof typeof DAY_MAPPING
-type WebtoonSortOption = typeof WEBTOON_SORT_OPTIONS[number];
 
 interface Webtoon {
   id: number;
@@ -22,4 +20,4 @@ interface WebtoonCardProps {
   thumbnail_url: string;
 }
 
-export type { DayOfWeek, WebtoonSortOption, Webtoon, DaySectionProps, WebtoonCardProps };
+export type { DayOfWeek, Webtoon, DaySectionProps, WebtoonCardProps };

--- a/src/types/webtoon.ts
+++ b/src/types/webtoon.ts
@@ -1,14 +1,14 @@
-type DayOfWeek = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun"
-type MainSortOption = "like" | "updated" | "view" | "rate"
+import { DAY_MAPPING } from "../constants/date.constants";
+import { WEBTOON_SORT_OPTIONS } from "../constants/webtoon.constants";
+
+type DayOfWeek = keyof typeof DAY_MAPPING
+type WebtoonSortOption = typeof WEBTOON_SORT_OPTIONS[number];
 
 interface Webtoon {
   id: number;
   title: string;
   day_of_week: DayOfWeek;
   thumbnail_url: string;
-  view_count: number;
-  favorite_count: number;
-  updated_at: string;
 }
 
 interface DaySectionProps {
@@ -22,4 +22,4 @@ interface WebtoonCardProps {
   thumbnail_url: string;
 }
 
-export type { DayOfWeek, MainSortOption, Webtoon, DaySectionProps, WebtoonCardProps };
+export type { DayOfWeek, WebtoonSortOption, Webtoon, DaySectionProps, WebtoonCardProps };


### PR DESCRIPTION
# 📝 설명

- 안녕하세요! 이번 PR에서는 메인 페이지에서의 상수&타입에 대해 지난번 코드 리뷰에서 받은 피드백을 반영하고 새롭게 정렬 기능을 구현하여, 메인 페이지의 기능을 완성하고자 하였습니다.
- 항상 리뷰 남겨주셔서 감사합니다. 많이 배우겠습니다!

## 🔨 상세

- 하드코딩돼 있던 요일 정렬 로직을 분리해 상수로 작성하여 타입 안정성을 높였습니다. (@ssi02014님 감사합니다!)
- 정렬 기준을 쿼리스트링으로 다루는 커스텀 훅을 도입했습니다.  
- 웹툰 목록 API 호출과 패칭 로직을 훅으로 모듈화했습니다.
- API 함수를 분리하고, `async/await` 문법으로 작성하였습니다. (기존의 auth 함수들도 리팩터링 진행했습니다. @zzzRYT님 감사합니다!)
- 메인 페이지를 작성하였습니다.
 
## 📌 PR 요약

- 상수, 타입 분리 (`constants/`, `types/webtoon.ts`)
- 쿼리 훅 도입 (`hooks/useSortQuery.ts`)
- 메인 페이지용 훅 구현 (`hooks/useWebtoons.ts`)
- API 함수 분리 (`apis/webtoons.ts`)
- 페이지 정리 (`pages/WebtoonMain.tsx`)
- 문법 개선 (`.then` 체이닝 -> `async/await` 문법 전환)

## ❗ 리뷰 포인트

- 상수와 타입을 둘 다 사용하고자 하여 `constants/`에 둘 다 작성하는 대신 이곳에 상수만 작성하고, 
기존의 `types/`에 위치한 `webtoon.ts` 파일에 import해서 타입을 작성하였습니다. 이 구조 괜찮을까요?
- `useSortQuery → useWebtoons` 흐름이 자연스러운지 피드백 부탁드립니다!

## 📎 관련 이슈

- #10 
